### PR TITLE
ExState with steps in addition to events

### DIFF
--- a/lib/underwork/cycles/sale.ex
+++ b/lib/underwork/cycles/sale.ex
@@ -1,0 +1,35 @@
+defmodule Underwork.Cycles.Sale do
+  use Ecto.Schema
+  use ExState.Ecto.Subject
+
+  import Ecto.Changeset
+
+  alias Underwork.Cycles.SaleWorkflow
+  alias Underwork.Cycles.User
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "sales" do
+    has_workflow SaleWorkflow
+    field :product_id, :string
+    field :cancelled_at, :utc_datetime
+    belongs_to :seller, User
+    belongs_to :buyer, User
+  end
+
+  def new(params) do
+    changeset(%__MODULE__{}, params)
+  end
+
+  def changeset(sale, params) do
+    sale
+    |> cast(params, [
+      :product_id,
+      :cancelled_at,
+      :seller_id,
+      :buyer_id,
+      :workflow_id
+    ])
+    |> validate_required([:product_id])
+  end
+end

--- a/lib/underwork/cycles/sale_workflow.ex
+++ b/lib/underwork/cycles/sale_workflow.ex
@@ -1,0 +1,64 @@
+defmodule Underwork.Cycles.SaleWorkflow do
+  use ExState.Definition
+
+  alias Underwork.Repo
+  alias Underwork.Cycles.Sale
+
+  workflow "sale" do
+    subject :sale, Sale
+
+    participant :seller
+    participant :buyer
+
+    initial_state :pending
+
+    state :unknown do
+      on :_, [:morning]
+    end
+
+    state :pending do
+      step :attach_document, participant: :seller
+      step :send, participant: :seller
+      on :cancelled, :cancelled
+      on :document_replaced, :_
+      on_completed :send, :sent
+    end
+
+    state :sent do
+      parallel do
+        step :acknowledge_receipt, participant: :buyer
+        step :close, participant: :seller
+      end
+
+      on :cancelled, :cancelled
+      on :document_replaced, :pending
+      on_completed :acknowledge_receipt, :receipt_acknowledged
+      on_completed :close, :closed
+    end
+
+    state :receipt_acknowledged do
+      step :close, participant: :seller
+      on_completed :close, :closed
+    end
+
+    state :closed do
+      final
+    end
+
+    state :cancelled do
+      final
+      on_entry :update_cancelled_at
+    end
+  end
+
+  def use_step?(_sale, _step), do: true
+
+  def guard_transition(_sale, _from, _to), do: :ok
+
+  def update_cancelled_at(%{sale: sale}) do
+    sale
+    |> Sale.changeset(%{cancelled_at: DateTime.utc_now()})
+    |> Repo.update()
+    |> updated(:sale)
+  end
+end

--- a/lib/underwork/cycles/user.ex
+++ b/lib/underwork/cycles/user.ex
@@ -1,0 +1,21 @@
+defmodule Underwork.Cycles.User do
+  use Ecto.Schema
+
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+  schema "users" do
+    field :name, :string
+  end
+
+  def new(params) do
+    changeset(%__MODULE__{}, params)
+  end
+
+  def changeset(sale, params) do
+    sale
+    |> cast(params, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/priv/repo/migrations/20230919022210_add_test_models_from_lib.exs
+++ b/priv/repo/migrations/20230919022210_add_test_models_from_lib.exs
@@ -1,0 +1,19 @@
+defmodule Underwork.Repo.Migrations.AddTestModelsFromLib do
+  use Ecto.Migration
+
+  def up do
+    create table(:users) do
+      add(:name, :string, null: false)
+    end
+
+    # ExState.Ecto.Migration.up(install_pgcrypto: true)
+
+    create table(:sales) do
+      add(:product_id, :string, null: false)
+      add(:cancelled_at, :utc_datetime)
+      add(:seller_id, references(:users, type: :uuid))
+      add(:buyer_id, references(:users, type: :uuid))
+      add(:workflow_id, references(:workflows, type: :uuid))
+    end
+  end
+end

--- a/test/underwork/cycles_test.exs
+++ b/test/underwork/cycles_test.exs
@@ -32,6 +32,13 @@ defmodule Underwork.CyclesTest do
       assert session.noteworthy == "some noteworthy"
     end
 
+    test "creating workflow for session" do
+      valid_attrs = %{accomplish: "some accomplish", complete: "some complete", distractions: "some distractions", important: "some important", measurable: "some measurable", noteworthy: "some noteworthy"}
+      assert {:ok, %Session{} = session} = Cycles.create_session(valid_attrs)
+
+      assert {:ok, %{context: %{session: session}}} = ExState.create(session)
+    end
+
     test "create_session/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Cycles.create_session(@invalid_attrs)
     end


### PR DESCRIPTION
I'm trying to understand the difference between events and steps. AFAICT you use events for external triggers you don't control (user input, etc) and steps are for unit of work type internal stuff. However I don't quite get why you would do this instead of just using events for everything and doing side effects within functions called by `on_entry` and `on_exit` hooks.